### PR TITLE
Add basic support for custom variables to existing actions

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,29 +9,33 @@ module.exports = {
 				name: 'Set On/Off Times',
 				options: [
 					{
-						type: 'number',
+						type: 'textinput',
 						label: 'On Time (ms)',
 						id: 'onTime',
 						default: 1000,
 						tooltip: 'The time in milliseconds the button will be on.',
 						required: true,
+						useVariables: true,
 						min: 100,
 						max: 10000
 					},
 					{
-						type: 'number',
+						type: 'textinput',
 						label: 'Off Time (ms)',
 						id: 'offTime',
 						default: 500,
 						tooltip: 'The time in milliseconds the button will be off.',
 						required: true,
+						useVariables: true,
 						min: 100,
 						max: 10000
 					}
 				],
 				callback: async function (action) {
-					let onTime = parseInt(action.options.onTime);
-					let offTime = parseInt(action.options.offTime);
+                    let onTime = parseInt(await(self.parseVariablesInString(action.options.onTime)));
+                    let offTime = parseInt(await(self.parseVariablesInString(action.options.offTime)));
+					console.log(`On time set to ${onTime}`);
+					console.log(`Off time set to ${offTime}`);
 					self.setOnOffTimes(onTime, offTime);
 				}
 			}
@@ -41,18 +45,20 @@ module.exports = {
 				name: 'Set Blink Rate',
 				options: [
 					{
-						type: 'number',
+						type: 'textinput',
 						label: 'Rate (ms)',
 						id: 'rate',
 						default: 1000,
 						tooltip: 'The rate in milliseconds at which the buttons will blink. 1000ms = 1 second.',
 						required: true,
+						useVariables: true,
 						min: 100,
 						max: 10000
 					}
 				],
 				callback: async function (action) {
-					let rate = parseInt(action.options.rate);
+                    let rate = parseInt(await(self.parseVariablesInString(action.options.rate)));
+					console.log(`rate set to : ${rate}`);
 					self.setRate(rate);
 				}
 			}

--- a/src/actions.js
+++ b/src/actions.js
@@ -34,8 +34,6 @@ module.exports = {
 				callback: async function (action) {
                     let onTime = parseInt(await(self.parseVariablesInString(action.options.onTime)));
                     let offTime = parseInt(await(self.parseVariablesInString(action.options.offTime)));
-					console.log(`On time set to ${onTime}`);
-					console.log(`Off time set to ${offTime}`);
 					self.setOnOffTimes(onTime, offTime);
 				}
 			}
@@ -58,7 +56,6 @@ module.exports = {
 				],
 				callback: async function (action) {
                     let rate = parseInt(await(self.parseVariablesInString(action.options.rate)));
-					console.log(`rate set to : ${rate}`);
 					self.setRate(rate);
 				}
 			}


### PR DESCRIPTION
This is an MVP for adding custom variables to the actions for the generic blink module!

This allows users to use custom variables when using the existing actions to set the blink rate (either the flat rate or specified on/off durations). Doing so unlocks use cases that require a dynamic value when setting the blink rate.

For example, this is the use case that led me to fork this: I created a Companion config where a user is tapping a button, a bpm is calculated from the taps, the bpm is converted into on/off time duration values in custom variables, and then the generic blink module (using this branch) is used to display that bpm visually by accepting the values of those on/off duration custom variables.

https://github.com/bitfocus/companion-module-generic-blink/assets/31675433/4e72a746-7760-47a3-96c3-430aec206b37

