### PR TITLE
Set an explicit yarn version

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -15,5 +15,6 @@
 	},
 	"devDependencies": {
 		"@companion-module/tools": "^1.5.0"
-	}
+	},
+	"packageManager": "yarn@4.8.1"
 }


### PR DESCRIPTION
The module isn't TypeScript so (I presume) requires a `corepack enable` and then a `yarn install` to install dependencies, then it's ready to roll.  But when I do this, it futzes up `package.json` with a manual yarn version, and it gunks up `yarn.lock` something fierce.

My node-fu is not terribly advanced, so maybe I'm not getting the commands right, possibly.  But it seems like setting an explicit yarn version (and [ignoring](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored) some newly created files that result) will solve all this, right?